### PR TITLE
Added support for multiple Chromecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ VERSION:
    0.0.1
 
 COMMANDS:
+    list      list available chromecasts
     status    current status of the chromecast
     pause     pause current media
     unpause   unpause current media
@@ -36,6 +37,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --debug, -d    log debug information
+   --uuid value, -u value  specify chromecast uuid
    --help, -h     show help
    --version, -v  print the version
 ```

--- a/cast_connection.go
+++ b/cast_connection.go
@@ -33,6 +33,9 @@ func NewCastConnection(chromecastUuid string, debug bool) *CastConnection {
 	log.Println("Getting dns entry")
 	// Find the dns entry for the chromecast
 	entry := getCastEntry(chromecastUuid)
+	if entry == nil {
+		return nil
+	}
 	log.Println("Got dns entry")
 
 	cc := &CastConnection{

--- a/cast_connection.go
+++ b/cast_connection.go
@@ -28,11 +28,11 @@ type CastConnection struct {
 	debug bool
 }
 
-func NewCastConnection(debug bool) *CastConnection {
+func NewCastConnection(chromecastUuid string, debug bool) *CastConnection {
 
 	log.Println("Getting dns entry")
 	// Find the dns entry for the chromecast
-	entry := getCastEntry()
+	entry := getCastEntry(chromecastUuid)
 	log.Println("Got dns entry")
 
 	cc := &CastConnection{

--- a/cast_connection.go
+++ b/cast_connection.go
@@ -40,7 +40,7 @@ type CastConnection struct {
 	debug bool
 }
 
-func NewCastConnection() *CastConnection {
+func NewCastConnection(debug bool) *CastConnection {
 
 	log.Println("Getting dns entry")
 	// Find the dns entry for the chromecast
@@ -57,7 +57,7 @@ func NewCastConnection() *CastConnection {
 		infoFields[splitField[0]] = splitField[1]
 	}
 
-	return &CastConnection{
+	cc := &CastConnection{
 		addrV4:          entry.AddrV4,
 		addrV6:          entry.AddrV6,
 		port:            entry.Port,
@@ -70,7 +70,11 @@ func NewCastConnection() *CastConnection {
 		status:          infoFields["rs"],
 		mhLock:          sync.Mutex{},
 		messageHandlers: make([]MessageHandler, 0),
+		debug:           debug,
 	}
+	cc.log("debug", "connection info: [IPv4=%s; IPv6=%s; port=%d; name=%s; host=%s; uuid=%s, device=%s, deviceName=%s, status=%s]",
+		cc.addrV4.String(), cc.addrV6.String(), cc.port, cc.name, cc.host, cc.uuid, cc.device, cc.deviceName, cc.status)
+	return cc
 }
 
 func (cc *CastConnection) addMessageHandler(f MessageHandler) {

--- a/cast_connection.go
+++ b/cast_connection.go
@@ -41,8 +41,7 @@ func NewCastConnection(debug bool) *CastConnection {
 		messageHandlers: make([]MessageHandler, 0),
 		debug:           debug,
 	}
-	cc.log("debug", "connection info: [IPv4=%s; IPv6=%s; port=%d; name=%s; host=%s; uuid=%s; device=%s; deviceName=%s; status=%s]",
-		cc.addrV4.String(), cc.addrV6.String(), cc.port, cc.name, cc.host, cc.uuid, cc.device, cc.deviceName, cc.status)
+	cc.log("debug", "connection info: %s", cc.String())
 	return cc
 }
 

--- a/cast_dns.go
+++ b/cast_dns.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"strings"
@@ -59,4 +60,9 @@ func fillCastEntry(entry *mdns.ServiceEntry) *CastEntry {
 		deviceName: infoFields["fn"],
 		status:     infoFields["rs"],
 	}
+}
+
+func (c *CastEntry) String() string {
+	return fmt.Sprintf("[IPv4=%s; IPv6=%s; port=%d; name=%s; host=%s; uuid=%s; device=%s; deviceName=%s; status=%s]",
+		c.addrV4.String(), c.addrV6.String(), c.port, c.name, c.host, c.uuid, c.device, c.deviceName, c.status)
 }

--- a/cast_dns.go
+++ b/cast_dns.go
@@ -1,12 +1,30 @@
 package main
 
 import (
+	"log"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/micro/mdns"
 )
 
-func getCastEntry() *mdns.ServiceEntry {
+type CastEntry struct {
+	addrV4 net.IP
+	addrV6 net.IP
+	port   int
+
+	name string
+	host string
+
+	uuid       string
+	device     string
+	status     string
+	deviceName string
+	infoFields map[string]string
+}
+
+func getCastEntry() *CastEntry {
 	entriesCh := make(chan *mdns.ServiceEntry, 1)
 
 	mdns.Query(&mdns.QueryParam{
@@ -16,5 +34,29 @@ func getCastEntry() *mdns.ServiceEntry {
 		Entries: entriesCh,
 	})
 
-	return <-entriesCh
+	return fillCastEntry(<-entriesCh)
+}
+
+func fillCastEntry(entry *mdns.ServiceEntry) *CastEntry {
+	infoFields := make(map[string]string, len(entry.InfoFields))
+	for _, infoField := range entry.InfoFields {
+		splitField := strings.Split(infoField, "=")
+		if len(splitField) != 2 {
+			log.Printf("[error] Incorrect format for field in entry.InfoFields: %s\n", infoField)
+			continue
+		}
+		infoFields[splitField[0]] = splitField[1]
+	}
+	return &CastEntry{
+		addrV4:     entry.AddrV4,
+		addrV6:     entry.AddrV6,
+		port:       entry.Port,
+		name:       entry.Name,
+		host:       entry.Host,
+		infoFields: infoFields,
+		uuid:       infoFields["id"],
+		device:     infoFields["md"],
+		deviceName: infoFields["fn"],
+		status:     infoFields["rs"],
+	}
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,11 @@ var (
 
 func initialise(ctx *cli.Context) error {
 	log.Println("Initalising")
-	castConn := NewCastConnection(ctx.GlobalBool("debug"))
+	// if uuid is not specified, the first chromecast is used
+	castConn := NewCastConnection(ctx.GlobalString("uuid"), ctx.GlobalBool("debug"))
+	if castConn == nil {
+		log.Fatalf("no chromecast found with uuid: %s", ctx.GlobalString("uuid"))
+	}
 	log.Println("Got cast connection")
 	castConn.connect()
 	log.Println("Finished connecting")
@@ -122,8 +126,20 @@ func main() {
 			Name:  "debug, d",
 			Usage: "log debug information",
 		},
+		cli.StringFlag{
+			Name:  "uuid, u",
+			Usage: "specify chromecast uuid",
+		},
 	}
 	app.Commands = []cli.Command{
+		{
+			Name:  "list",
+			Usage: "list available chromecasts",
+			Action: func(c *cli.Context) error {
+				printCastEntries()
+				return nil
+			},
+		},
 		{
 			Name:  "status",
 			Usage: "current status of the chromecast",

--- a/main.go
+++ b/main.go
@@ -27,9 +27,8 @@ var (
 
 func initialise(ctx *cli.Context) error {
 	log.Println("Initalising")
-	castConn := NewCastConnection()
+	castConn := NewCastConnection(ctx.GlobalBool("debug"))
 	log.Println("Got cast connection")
-	castConn.debug = ctx.GlobalBool("debug")
 	castConn.connect()
 	log.Println("Finished connecting")
 	go castConn.receiveLoop()


### PR DESCRIPTION
You can list available Chromecasts and target specifically one of them with `-u` flag. It should work as before (i.e. using the first available Chromecast) when you don't specify the uuid.