### PR TITLE
cmd: added ls command

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -1,0 +1,40 @@
+// Copyright © 2018 Jonathan Pentecost <pentecostjonathan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	castdns "github.com/vishen/go-chromecast/dns"
+)
+
+// lsCmd represents the ls command
+var lsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List devices",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dnsEntries := castdns.FindCastDNSEntries()
+		fmt.Printf("Found %d cast dns entries\n", len(dnsEntries))
+		for i, d := range dnsEntries {
+			fmt.Printf("%d) device=%q device_name=%q address=\"%s:%d\" status=%q uuid=%q\n", i+1, d.Device, d.DeviceName, d.AddrV4, d.Port, d.Status, d.UUID)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(lsCmd)
+}


### PR DESCRIPTION
Add a 'ls' command that will list all available cast devices, this
should include chromecasts and google home devices.

Updates #5