### PR TITLE
WIP: Launch Default Application if no applications are found

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -131,6 +131,8 @@ func (a *Application) Update() error {
 		a.log("more than 1 connected application on the chromecast: (%d)%#v", len(recvStatus.Status.Applications), recvStatus.Status.Applications)
 	} else if len(recvStatus.Status.Applications) == 0 {
 		a.log("no applications running, starting default application")
+		
+		// Start Default Application
         	_, err := a.sendAndWaitDefaultRecv(&cast.LaunchRequest{
             		PayloadHeader: cast.LaunchHeader,
             		AppId:         defaultChromecastAppId,
@@ -138,6 +140,12 @@ func (a *Application) Update() error {
 		if err != nil {
             		return err
         	}
+		
+		// Refresh Status
+		recvStatus, err := a.getReceiverStatus()
+		if err != nil {
+			return err
+		}
 	}
 
 	// TODO(vishen): Why could there be more than one application, how to handle this?
@@ -147,9 +155,9 @@ func (a *Application) Update() error {
 	}
 	a.volume = &recvStatus.Status.Volume
 
-	//if a.application.IsIdleScreen {
-	//	return nil
-	//} Causes nilptr exception when running load command (mtbucci)
+	if a.application.IsIdleScreen {
+		return nil
+	}
 
 	a.updateMediaStatus()
 

--- a/application/application.go
+++ b/application/application.go
@@ -130,8 +130,16 @@ func (a *Application) Update() error {
 	if len(recvStatus.Status.Applications) > 1 {
 		a.log("more than 1 connected application on the chromecast: (%d)%#v", len(recvStatus.Status.Applications), recvStatus.Status.Applications)
 	} else if len(recvStatus.Status.Applications) == 0 {
-		return errors.New("no applications running")
+		a.log("no applications running, starting default application")
+        	_, err := a.sendAndWaitDefaultRecv(&cast.LaunchRequest{
+            		PayloadHeader: cast.LaunchHeader,
+            		AppId:         defaultChromecastAppId,
+        	})
+		if err != nil {
+            		return err
+        	}
 	}
+
 	// TODO(vishen): Why could there be more than one application, how to handle this?
 	// For now just take the last one.
 	for _, app := range recvStatus.Status.Applications {
@@ -139,9 +147,9 @@ func (a *Application) Update() error {
 	}
 	a.volume = &recvStatus.Status.Volume
 
-	if a.application.IsIdleScreen {
-		return nil
-	}
+	//if a.application.IsIdleScreen {
+	//	return nil
+	//} Causes nilptr exception when running load command (mtbucci)
 
 	a.updateMediaStatus()
 


### PR DESCRIPTION
Addresses https://github.com/vishen/go-chromecast/issues/7

This worked for me, but I'm not sure why the behavior before was to return nil on Idle, maybe commenting out that line will break some other commands, additionally I'm thinking this application launch code might be better placed in the "Start" function. 

I'll wait till I hear back to make any changes, but this solved my issue for the time being.
I'm using this library to trigger sounds from smartthings on my google home devices. 