### PR TITLE
application: added a basic retry for if the device becomes unavailable

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -182,7 +182,18 @@ func (a *Application) writePlayedItems() error {
 }
 
 func (a *Application) Update() error {
-	recvStatus, err := a.getReceiverStatus()
+	var recvStatus *cast.ReceiverStatusResponse
+	var err error
+	// Simple retry. We need this for when the device isn't currently
+	// available, but it is likely that it will come up soon.
+	for i := 0; i < 5; i++ {
+		recvStatus, err = a.getReceiverStatus()
+		if err == nil {
+			break
+		}
+		a.log("unable to get status from device; attempt %d/5, retrying...", i+1)
+		time.Sleep(time.Second * 2)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -27,7 +27,7 @@ var lsCmd = &cobra.Command{
 	Short: "List devices",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dnsEntries := castdns.FindCastDNSEntries()
-		fmt.Printf("Found %d cast dns entries\n", len(dnsEntries))
+		fmt.Printf("Found %d cast devices\n", len(dnsEntries))
 		for i, d := range dnsEntries {
 			fmt.Printf("%d) device=%q device_name=%q address=\"%s:%d\" status=%q uuid=%q\n", i+1, d.Device, d.DeviceName, d.AddrV4, d.Port, d.Status, d.UUID)
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -29,9 +29,6 @@ var statusCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := app.Update(); err != nil {
-			return err
-		}
 		castApplication, castMedia, castVolume := app.Status()
 		if castApplication == nil {
 			fmt.Printf("Idle, volume=%0.2f muted=%t\n", castVolume.Level, castVolume.Muted)


### PR DESCRIPTION
Basic retry mechanism for when the device becomes unavailable for
whatever reason. We do this in the 'Update' function. This is called
quite often so seems like the best place to do this.

Closes #10