### PR TITLE
FLAC audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported Media formats:
     - MKV
     - MP4
     - WebM
+    - FLAC
 ```
 
 If an unknown file is found, it will use `ffmpeg` to transcode it to MP4, and stream it to the chromecast.

--- a/application/application.go
+++ b/application/application.go
@@ -416,6 +416,8 @@ func (a *Application) possibleContentType(filename string) (string, error) {
 		return "video/webm", nil
 	case ".mp3":
 		return "audio/mp3", nil
+	case ".flac":
+		return "audio/flac", nil
 	default:
 		return "", fmt.Errorf("unknown file extension %q", ext)
 	}


### PR DESCRIPTION
Chromecast supports FLAC natively, just a matter of detecting the file-extension and supplying the right media-type.

Awesome project by the way JP!