### PR TITLE
Add volume subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Available Commands:
   tts         text-to-speech
   ui          Run the UI
   unpause     Unpause the currently playing media on the chromecast
+  volume      Get or set volume
   watch       Watch all events sent from a chromecast device
 
 Flags:
@@ -163,6 +164,12 @@ $ go-chromecast rewind 30
 
 # Go forward in the currently playing media by x seconds.
 $ go-chromecast seek 30
+
+# Get the current volume level
+$ go-chromecast volume
+
+# Set the volume level
+$ go-chromecast volume 0.55
 
 # View what a cast device is sending out.
 $ go-chromecast watch

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -1,0 +1,62 @@
+// Copyright © 2018 Jonathan Pentecost <pentecostjonathan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+// volumeCmd represents the volume command
+var volumeCmd = &cobra.Command{
+	Use:   "volume [<0.00 - 1.00>]",
+	Short: "Get or set volume",
+	Long:  "Get or set volume (float in range from 0 to 1)",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := castApplication(cmd, args)
+		if err != nil {
+			fmt.Printf("unable to get cast application: %v\n", err)
+			return
+		}
+
+		if len(args) == 1 && args[0] != "" {
+			newVolume, err := strconv.ParseFloat(args[0], 32)
+			if err != nil {
+				fmt.Printf("invalid volume: %v\n", err)
+				return
+			}
+			if err = app.SetVolume(float32(newVolume)); err != nil {
+				fmt.Printf("failed to set volume: %v\n", err)
+				return
+			}
+		}
+
+		if err = app.Update(); err != nil {
+			fmt.Printf("unable to update cast info: %v\n", err)
+			return
+		}
+		_, _, castVolume := app.Status()
+
+		fmt.Printf("%0.2f\n", castVolume.Level)
+
+		return
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(volumeCmd)
+}


### PR DESCRIPTION
The volume subcommand can get and change volumes.

I want to change the volume instantly like below.

```bash
saved_volume=$(go-chromecast -n $NODE_NAME volume)
go-chromecast -n $NODE_NAME tts "$MESSAGE" --google-service-account ~/account.json
go-chromecast -n $NODE_NAME volume saved_volume
```