### PR TITLE
application: specify the audio codec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,4 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	google.golang.org/api v0.3.0
 	google.golang.org/genproto v0.0.0-20190321212433-e79c0c59cdb5
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
Cromecast generations 1 and 2 can only use mp3 or aac audio codecs.
ffmpeg already defaulted to aac it seems, but the chromecast would
immediately error if the original audio had more than two channels,
which is not supported. Force two channels.

While at it, remove the buggy use of ExitError. Its Stderr field is only
set by calling Cmd.Output, which we don't. Instead, make --debug send
ffmpeg's stderr directly to os.Stderr. This is very useful when
debugging ffmpeg issues.