### PR TITLE
version: added version flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ before:
 builds:
 - env:
   - CGO_ENABLED=0
+  ldflags:
+  - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
 archive:
   replacements:
     darwin: Darwin

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,15 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	Version = ""
+	Commit  = ""
+	Date    = ""
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -26,12 +33,31 @@ var rootCmd = &cobra.Command{
 	Use:   "go-chromecast",
 	Short: "CLI for interacting with the Google Chromecast",
 	Long: `Control your Google Chromecast or Google Home Mini from the
-command line.
-`}
+command line.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printVersion, _ := cmd.Flags().GetBool("version")
+		if printVersion {
+			if len(Version) > 0 && Version[0] != 'v' && Version != "dev" {
+				Version = "v" + Version
+			}
+			fmt.Printf("go-chromecast %s (%s) %s\n", Version, Commit, Date)
+			return nil
+		}
+		cmd.Help()
+		return nil
+	},
+}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
+func Execute(version, commit, date string) {
+	Version = version
+	Commit = commit
+	if date != "" {
+		Date = date
+	} else {
+		Date = time.Now().UTC().Format(time.RFC3339)
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -39,7 +65,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().Bool("debug", false, "debug logging")
+	rootCmd.PersistentFlags().Bool("version", false, "display command version")
+	rootCmd.PersistentFlags().BoolP("debug", "v", false, "debug logging")
 	rootCmd.PersistentFlags().Bool("disable-cache", false, "disable the cache")
 	rootCmd.PersistentFlags().Bool("with-ui", false, "run with a UI")
 	rootCmd.PersistentFlags().StringP("device", "d", "", "chromecast device, ie: 'Chromecast' or 'Google Home Mini'")

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	google.golang.org/api v0.3.0
 	google.golang.org/genproto v0.0.0-20190321212433-e79c0c59cdb5
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -16,6 +16,13 @@ package main
 
 import "github.com/vishen/go-chromecast/cmd"
 
+var (
+	// These are build-time variables that get set by goreleaser.
+	version = "dev"
+	commit  = "master"
+	date    = ""
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version, commit, date)
 }


### PR DESCRIPTION
Added a version flag '--version' which will output the current release
and the git commit short sha. These are compiled into the binary when
from goreleaser.

Fixes: #28