### PR TITLE
cmd,application: exit when external media finished playing

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -46,12 +46,13 @@ that ffmpeg is installed.`,
 
 		contentType, _ := cmd.Flags().GetString("content-type")
 		transcode, _ := cmd.Flags().GetBool("transcode")
+		detach, _ := cmd.Flags().GetBool("detach")
 
 		// Optionally run a UI when playing this media:
 		runWithUI, _ := cmd.Flags().GetBool("with-ui")
 		if runWithUI {
 			go func() {
-				if err := app.Load(args[0], contentType, transcode); err != nil {
+				if err := app.Load(args[0], contentType, transcode, detach); err != nil {
 					logrus.WithError(err).Fatal("unable to load media")
 				}
 			}()
@@ -64,7 +65,7 @@ that ffmpeg is installed.`,
 		}
 
 		// Otherwise just run in CLI mode:
-		if err := app.Load(args[0], contentType, transcode); err != nil {
+		if err := app.Load(args[0], contentType, transcode, detach); err != nil {
 			fmt.Printf("unable to load media: %v\n", err)
 			return nil
 		}
@@ -75,5 +76,6 @@ that ffmpeg is installed.`,
 func init() {
 	rootCmd.AddCommand(loadCmd)
 	loadCmd.Flags().Bool("transcode", true, "transcode the media to mp4 if media type is unrecognised")
+	loadCmd.Flags().Bool("detach", false, "detach from waiting until media finished. Only works with url loaded external media")
 	loadCmd.Flags().StringP("content-type", "c", "", "content-type to serve the media file as")
 }

--- a/cmd/tts.go
+++ b/cmd/tts.go
@@ -29,7 +29,7 @@ var ttsCmd = &cobra.Command{
 	Short: "text-to-speech",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		if (len(args) != 1 || args[0] == "") {
+		if len(args) != 1 || args[0] == "" {
 			fmt.Printf("expected exactly one argument to convert to speech\n")
 			return
 		}
@@ -76,7 +76,7 @@ var ttsCmd = &cobra.Command{
 			return
 		}
 
-		if err := app.Load(f.Name(), "audio/mp3", false); err != nil {
+		if err := app.Load(f.Name(), "audio/mp3", false, false); err != nil {
 			fmt.Printf("unable to load media to device: %v\n", err)
 			return
 		}


### PR DESCRIPTION
Fix a bug where go-chromecast wouldn't exit if the media was externally
loaded media content.

Added a detach flag for 'load' which will exit as soon as external media
content has been loaded.

Fixes: #36