### PR TITLE
ui: sync paused state with media player state

### DIFF
--- a/ui/update_status.go
+++ b/ui/update_status.go
@@ -71,6 +71,11 @@ func (ui *UserInterface) updateStatus(sleepTime time.Duration) {
 			fmt.Fprintf(viewStatus, "%sDetail: %s%s%s\n", normalTextColour, boldTextColour, castApplication.StatusText, resetTextColour)
 		}
 
+		// Update the player status:
+		if castMedia != nil {
+			ui.paused = castMedia.PlayerState == "PAUSED"
+		}
+
 		// Update the playback position:
 		if castMedia != nil {
 			ui.positionCurrent = castMedia.CurrentTime


### PR DESCRIPTION
When using the ui, the play/pause button does not "work" when the media state is changed from an other remote (it works the second time you press it though).
This will sync the ui `paused` boolean with the media status.