### PR TITLE
Use local IP from existing conn for local server

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -80,7 +80,6 @@ type Application struct {
 
 	httpServer *http.Server
 	serverPort int
-	localIP    string
 	iface      string
 
 	// NOTE: Currently only playing one media file at a time is handled
@@ -690,10 +689,11 @@ func (a *Application) loadAndServeFiles(filenames []string, contentType string, 
 	}
 
 	// TODO: maybe cache this somewhere
-	localIP, err := a.getLocalIP()
+	localIP, err := a.conn.LocalAddr()
 	if err != nil {
 		return nil, err
 	}
+	a.log("local IP address: %s", localIP)
 
 	a.log("starting streaming server...")
 	// Start server to serve the media
@@ -709,52 +709,6 @@ func (a *Application) loadAndServeFiles(filenames []string, contentType string, 
 	}
 
 	return mediaItems, nil
-}
-
-func (a *Application) getLocalIP() (string, error) {
-	if a.localIP != "" {
-		return a.localIP, nil
-	}
-
-	var addrs []net.Addr
-	if a.iface == "" {
-		var err error
-		addrs, err = net.InterfaceAddrs()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		ifs, err := net.Interfaces()
-		if err != nil {
-			return "", err
-		}
-
-		var foundIface net.Interface
-		for _, i := range ifs {
-			if i.Name == a.iface {
-				foundIface = i
-				break
-			}
-		}
-		if foundIface.Name == "" {
-			return "", fmt.Errorf("no network interface with name %q exists", a.iface)
-		}
-		addrs, err = foundIface.Addrs()
-		if err != nil {
-			return "", err
-		}
-	}
-	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			// TODO(vishen): Fallback to ipv6 if ipv4 fails? Or maybe do the other
-			// way around? I am unsure if chromecast supports ipv6???
-			if ipnet.IP.To4() != nil {
-				a.localIP = ipnet.IP.String()
-				return a.localIP, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("Failed to get local ip address")
 }
 
 func (a *Application) startStreamingServer() error {

--- a/cast/connection.go
+++ b/cast/connection.go
@@ -55,6 +55,11 @@ func (c *Connection) Start(addr string, port int) error {
 
 func (c *Connection) SetDebug(debug bool) { c.debug = debug }
 
+func (c *Connection) LocalAddr() (addr string, err error) {
+	host, _, err := net.SplitHostPort(c.conn.LocalAddr().String())
+	return host, err
+}
+
 func (c *Connection) log(message string, args ...interface{}) {
 	if c.debug {
 		log.WithField("package", "cast").Debugf(message, args...)


### PR DESCRIPTION
I was having trouble casting local files. It ended up being because go-chromecast was picking a 169.254.x.x IP address in `getLocalIP()` and telling the Chromecast to connect to that address for the embedded HTTP server. This pull request changes the logic to instead get the local IP address from the existing TCP connection to the Cast device, which I think will be more robust on multi-homed hosts.

Incidentally I've been using this on Windows (which works well so far). Thanks for making go-chromecast!