### PR TITLE
Set UI volume based on received status messages

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -44,7 +44,7 @@ func NewUserInterface(app *application.Application) (*UserInterface, error) {
 		gui:             g,
 		seekFastforward: 15,
 		seekRewind:      -15,
-		volume:          100,
+		volume:          0,
 	}
 
 	// Tell the GUI about its "Manager" function (defines the gocui "views"):

--- a/ui/update_status.go
+++ b/ui/update_status.go
@@ -85,6 +85,12 @@ func (ui *UserInterface) updateStatus(sleepTime time.Duration) {
 			ui.positionTotal = 0
 		}
 
+		// Update volume status
+		if castVolume != nil {
+			ui.volume = int(castVolume.Level * 100)
+			ui.muted = castVolume.Muted
+		}
+
 		// Update the "progress" view:
 		if castMedia != nil {
 			viewProgress.Clear()

--- a/ui/update_status.go
+++ b/ui/update_status.go
@@ -85,12 +85,6 @@ func (ui *UserInterface) updateStatus(sleepTime time.Duration) {
 			ui.positionTotal = 0
 		}
 
-		// Update volume status
-		if castVolume != nil {
-			ui.volume = int(castVolume.Level * 100)
-			ui.muted = castVolume.Muted
-		}
-
 		// Update the "progress" view:
 		if castMedia != nil {
 			viewProgress.Clear()
@@ -105,13 +99,12 @@ func (ui *UserInterface) updateStatus(sleepTime time.Duration) {
 
 		// Update the "volume" view:
 		if castVolume != nil {
+			ui.volume = int(castVolume.Level * 100)
+			ui.muted = castVolume.Muted
+
 			viewVolume.Clear()
 			if ui.muted {
-				if castVolume.Muted {
-					fmt.Fprintf(viewVolume, "%s(muted)", volumeMutedColour)
-				} else {
-					fmt.Fprintf(viewVolume, "%s(muted)", volumeColour)
-				}
+				fmt.Fprintf(viewVolume, "%s(muted)", volumeMutedColour)
 			} else {
 				for i := 0; i < ui.volume/5; i++ {
 					fmt.Fprintf(viewVolume, "%s#", volumeColour)


### PR DESCRIPTION
Unless I'm missing something, it looks like the UI never updates the volume indicator with the value from received status messages (it only updates when changed locally in the UI). This, combined with the default value of 100% means that the volume up action says "Already at max" and volume down sets the volume at 0.95 which can be very loud depending on speaker settings.

This PR updates the volume UI based on the status messages in the same manner as the progress UI. Additionally, it changes the default volume value to 0 before a status message is received to prevent accidentally setting a very loud volume.

I'm using go-chromecast with Chromecast Audio devices which is why this is a problem. I suspect regular video Chromecast devices don't typically use the volume control, relying on the TV volume instead?