### PR TITLE
add --first flag (-f) to use the first device

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -43,13 +43,13 @@ var lsCmd = &cobra.Command{
 }
 
 func listDevices(scanDuration time.Duration) ([]*discovery.Device, error) {
-	service := discovery.Service{
+	discover := discovery.Service{
 		Scanner: zeroconf.Scanner{Logger: log.New()},
 	}
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, scanDuration)
 	defer cancel()
-	return service.Sorted(ctx)
+	return discover.Sorted(ctx)
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "v", false, "debug logging")
 	rootCmd.PersistentFlags().Bool("disable-cache", false, "disable the cache")
 	rootCmd.PersistentFlags().Bool("with-ui", false, "run with a UI")
+	rootCmd.PersistentFlags().BoolP("first", "f", false, "use the first chromecast device found")
 	rootCmd.PersistentFlags().StringP("device", "d", "", "chromecast device, ie: 'Chromecast' or 'Google Home Mini'")
 	rootCmd.PersistentFlags().StringP("device-name", "n", "", "chromecast device name")
 	rootCmd.PersistentFlags().StringP("uuid", "u", "", "chromecast device uuid")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -29,8 +29,8 @@ var (
 	cache = storage.NewStorage()
 )
 
-// CastDNSEntry is used by DNS and caching discovery
-type CastDNSEntry interface {
+// castDNSEntry is the common interface between DNS discovery and caching entries
+type castDNSEntry interface {
 	GetName() string
 	GetUUID() string
 	GetAddr() string
@@ -71,7 +71,7 @@ func castApplication(cmd *cobra.Command, args []string) (*application.Applicatio
 	iface, _ := cmd.Flags().GetString("iface")
 	first, _ := cmd.Flags().GetBool("first")
 
-	var entry CastDNSEntry
+	var entry castDNSEntry
 	// If no address was specified, attempt to determine the address of any
 	// local chromecast devices.
 	if addr == "" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -161,21 +161,21 @@ func deviceMatchers(deviceType, deviceName, deviceUuid string) []discovery.Devic
 
 func selectFirstDevice(deviceType, deviceName, deviceUuid string) (*discovery.Device, error) {
 	matchers := deviceMatchers(deviceType, deviceName, deviceUuid)
-	service := discovery.Service{
+	discover := discovery.Service{
 		Scanner: zeroconf.Scanner{Logger: log.New()},
 	}
-	return service.First(context.Background(), matchers...)
+	return discover.First(context.Background(), matchers...)
 }
 
 func makeDeviceList(deviceType, deviceName, deviceUuid string) ([]*discovery.Device, error) {
 	matchers := deviceMatchers(deviceType, deviceName, deviceUuid)
-	service := discovery.Service{
+	discover := discovery.Service{
 		Scanner: zeroconf.Scanner{Logger: log.New()},
 	}
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	return service.Sorted(ctx, matchers...)
+	return discover.Sorted(ctx, matchers...)
 }
 
 func selectDevice(device, deviceName, deviceUuid string) (*discovery.Device, error) {

--- a/discovery/device.go
+++ b/discovery/device.go
@@ -15,6 +15,7 @@ func NewDevice(ip net.IP, port int, properties []string) *Device {
 	}
 }
 
+// Device represents a device discoverd on the network
 type Device struct {
 	IP         net.IP
 	Port       int
@@ -35,7 +36,7 @@ func (d Device) GetPort() int {
 	return d.Port
 }
 
-// Kind of more idiomatic method
+// Kind of more idiomatic methods:
 
 // Addr return the ip and port of the device
 func (d Device) Addr() string {

--- a/discovery/device.go
+++ b/discovery/device.go
@@ -21,7 +21,7 @@ type Device struct {
 	Properties map[string]string
 }
 
-// Compatibility with dns.CastDNSEntry
+// Compatibility with cmd.CastDNSEntry
 func (d Device) GetName() string {
 	return d.Name()
 }
@@ -35,22 +35,29 @@ func (d Device) GetPort() int {
 	return d.Port
 }
 
+// Kind of more idiomatic method
+
+// Addr return the ip and port of the device
 func (d Device) Addr() string {
 	return fmt.Sprintf("%s:%d", d.IP, d.Port)
 }
 
+// Name of the device
 func (d Device) Name() string {
 	return d.Properties["fn"]
 }
 
+// ID of the device (example: 7a5fd8ff1f425150a79ec0e36f497445)
 func (d Device) ID() string {
 	return d.Properties["id"]
 }
 
+// Type of the device (examples: Chromecast, Google Home Mini)
 func (d Device) Type() string {
 	return d.Properties["md"]
 }
 
+// Status of the device
 func (d Device) Status() string {
 	return d.Properties["rs"]
 }

--- a/discovery/device.go
+++ b/discovery/device.go
@@ -1,0 +1,69 @@
+package discovery
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// NewDevice returns an new chromecast device
+func NewDevice(ip net.IP, port int, properties []string) *Device {
+	return &Device{
+		IP:         ip,
+		Port:       port,
+		Properties: parseProperties(properties),
+	}
+}
+
+type Device struct {
+	IP         net.IP
+	Port       int
+	Properties map[string]string
+}
+
+// Compatibility with dns.CastDNSEntry
+func (d Device) GetName() string {
+	return d.Name()
+}
+func (d Device) GetUUID() string {
+	return d.ID()
+}
+func (d Device) GetAddr() string {
+	return d.IP.String()
+}
+func (d Device) GetPort() int {
+	return d.Port
+}
+
+func (d Device) Addr() string {
+	return fmt.Sprintf("%s:%d", d.IP, d.Port)
+}
+
+func (d Device) Name() string {
+	return d.Properties["fn"]
+}
+
+func (d Device) ID() string {
+	return d.Properties["id"]
+}
+
+func (d Device) Type() string {
+	return d.Properties["md"]
+}
+
+func (d Device) Status() string {
+	return d.Properties["rs"]
+}
+
+// parseProperties into a string map
+// Input: {"key1=value1", "key2=value2"}
+func parseProperties(s []string) map[string]string {
+	m := make(map[string]string, len(s))
+	for _, v := range s {
+		s := strings.SplitN(v, "=", 2)
+		if len(s) == 2 {
+			m[s[0]] = s[1]
+		}
+	}
+	return m
+}

--- a/discovery/device.go
+++ b/discovery/device.go
@@ -36,8 +36,6 @@ func (d Device) GetPort() int {
 	return d.Port
 }
 
-// Kind of more idiomatic methods:
-
 // Addr return the ip and port of the device
 func (d Device) Addr() string {
 	return fmt.Sprintf("%s:%d", d.IP, d.Port)

--- a/discovery/device_test.go
+++ b/discovery/device_test.go
@@ -1,0 +1,50 @@
+package discovery
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	castdns "github.com/vishen/go-chromecast/dns"
+)
+
+var _ castdns.CastDNSEntry = Device{}
+
+func TestParseProperties(t *testing.T) {
+
+	txt := `id=87cf98a003f1f1dbd2efe6d19055a617|ve=04|md=Chromecast|ic=/setup/icon.png|fn=Chromecast PO|ca=5|st=0|bs=FA8FCA7EE8A9|rs=`
+
+	exp := map[string]string{
+		"id": "87cf98a003f1f1dbd2efe6d19055a617",
+		"ve": "04",
+		"md": "Chromecast",
+		"ic": "/setup/icon.png",
+		"fn": "Chromecast PO",
+		"ca": "5",
+		"st": "0",
+		"bs": "FA8FCA7EE8A9",
+		"rs": "",
+	}
+
+	got := parseProperties(strings.Split(txt, "|"))
+
+	if !mapEqual(exp, got) {
+		t.Errorf("expected %s, got: %s", exp, got)
+	}
+}
+
+func mapEqual(m1, m2 map[string]string) bool {
+	if m1 == nil {
+		return m2 == nil
+	}
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v1 := range m1 {
+		if v2, ok := m2[k]; !ok || v1 != v2 {
+			fmt.Println(k, v1, v2, ok)
+			return false
+		}
+	}
+	return true
+}

--- a/discovery/device_test.go
+++ b/discovery/device_test.go
@@ -4,11 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	castdns "github.com/vishen/go-chromecast/dns"
 )
-
-var _ castdns.CastDNSEntry = Device{}
 
 func TestParseProperties(t *testing.T) {
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,4 +1,4 @@
-// Package discovery is used to discover devices on the network using a scanner
+// Package discovery is used to discover devices on the network using a provided scanner
 package discovery
 
 import (
@@ -9,7 +9,7 @@ import (
 
 // Scanner scans for chromecast and pushes them onto the results channel (eventually multiple times)
 // It must return immediately and scan in a different goroutine
-// The the results channel must be closed  when the ctx is done
+// The results channel must be closed when the ctx is done
 type Scanner interface {
 	Scan(ctx context.Context, results chan<- *Device) error
 }

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,0 +1,43 @@
+// Package discovery is used to discover devices on the network using a scanner
+package discovery
+
+import (
+	"context"
+	"fmt"
+)
+
+// Scanner scans for chromecast and pushes them onto the results channel (eventually multiple times)
+// It must return immediately and scan in a different goroutine
+// The the results channel must be closed  when the ctx is done
+type Scanner interface {
+	Scan(ctx context.Context, results chan<- *Device) error
+}
+
+// Service allows to discover chromecast via the given scanner
+type Service struct {
+	Scanner Scanner
+}
+
+// First returns the first chromecast that is discovered by the scanner (matching all matchers - if any)
+func (s Service) First(ctx context.Context, matchers ...DeviceMatcher) (*Device, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // cancel child-ctx when the right client has been found
+
+	result := make(chan *Device, 1)
+
+	err := s.Scanner.Scan(ctx, result)
+	if err != nil {
+		return nil, fmt.Errorf("could not initiliaze scanner: %v", err)
+	}
+	match := matchAll(matchers...)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case device := <-result:
+			if match(device) {
+				return device, nil
+			}
+		}
+	}
+}

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,0 +1,158 @@
+package discovery_test
+
+import (
+	"testing"
+	"time"
+
+	"context"
+
+	"github.com/vishen/go-chromecast/discovery"
+)
+
+type MockedScanner struct {
+	ScanFuncCalled int
+	ScanFunc       func(ctx context.Context, results chan<- *discovery.Device) error
+}
+
+func (s *MockedScanner) Scan(ctx context.Context, results chan<- *discovery.Device) error {
+	s.ScanFuncCalled++
+	return s.ScanFunc(ctx, results)
+}
+
+func TestFirstDirect(t *testing.T) {
+	scan := MockedScanner{
+		ScanFunc: func(ctx context.Context, results chan<- *discovery.Device) error {
+			go func() {
+				results <- &discovery.Device{}
+				close(results)
+			}()
+			return nil
+		},
+	}
+
+	service := discovery.Service{Scanner: &scan}
+
+	ctx := context.Background()
+
+	first, err := service.First(ctx)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if first == nil {
+		t.Errorf("a client should have been found")
+	}
+	if scan.ScanFuncCalled != 1 {
+		t.Errorf("scanner should have been called once, and not %d times", scan.ScanFuncCalled)
+	}
+}
+
+func TestFirstCancelled(t *testing.T) {
+	scan := MockedScanner{
+		ScanFunc: func(ctx context.Context, results chan<- *discovery.Device) error {
+			go func() {
+				<-ctx.Done()
+			}()
+			return nil
+		},
+	}
+
+	service := discovery.Service{Scanner: &scan}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	first, err := service.First(ctx)
+	if err != ctx.Err() {
+		t.Errorf("unexpected error %v", err)
+	}
+	if first != nil {
+		t.Errorf("a client should not have been found")
+	}
+	if scan.ScanFuncCalled > 1 {
+		t.Errorf("scanner should have been called at most once, and not %d times", scan.ScanFuncCalled)
+	}
+}
+
+func TestNamedDirect(t *testing.T) {
+	scan := MockedScanner{}
+	done := make(chan struct{})
+	scan.ScanFunc = func(ctx context.Context, results chan<- *discovery.Device) error {
+		go func() {
+			defer close(results)
+			results <- &discovery.Device{}
+			c := &discovery.Device{
+				Properties: map[string]string{
+					"fn": "casti",
+				},
+			}
+			results <- c
+			results <- &discovery.Device{}
+			select {
+			case results <- &discovery.Device{}:
+				t.Error("channel should have been full")
+			case <-ctx.Done():
+			}
+			close(done)
+		}()
+		return nil
+	}
+
+	service := discovery.Service{Scanner: &scan}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	first, err := service.First(ctx, discovery.WithName("casti"))
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if first == nil {
+		t.Fatalf("a client should have been found")
+	}
+	if first.Name() != "casti" {
+		t.Errorf("the client should been named 'casti' and not '%s'", first.Name())
+	}
+	if scan.ScanFuncCalled != 1 {
+		t.Errorf("scanner should have been called once, and not %d times", scan.ScanFuncCalled)
+	}
+	<-done
+}
+
+func TestNamedCancelled(t *testing.T) {
+	scan := MockedScanner{}
+	done := make(chan struct{})
+	scan.ScanFunc = func(ctx context.Context, results chan<- *discovery.Device) error {
+		go func() {
+			defer close(results)
+			for {
+				select {
+				case results <- &discovery.Device{}:
+				case <-ctx.Done():
+					close(done)
+					return
+				}
+			}
+		}()
+		return nil
+	}
+
+	service := discovery.Service{Scanner: &scan}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	first, err := service.First(ctx, discovery.WithName("casti"))
+	if err != ctx.Err() {
+		t.Errorf("unexpected error %v", err)
+	}
+	if err != ctx.Err() {
+		t.Errorf("unexpected error %v", err)
+	}
+	if first != nil {
+		t.Errorf("a client should not have been found")
+	}
+	if scan.ScanFuncCalled > 1 {
+		t.Errorf("scanner should have been called at most once, and not %d times", scan.ScanFuncCalled)
+	}
+	<-done
+}

--- a/discovery/matcher.go
+++ b/discovery/matcher.go
@@ -1,0 +1,36 @@
+package discovery
+
+// DeviceMatcher allows to specicy which device should be accepted
+type DeviceMatcher func(*Device) bool
+
+// WithName matches a device by its name
+func WithName(name string) DeviceMatcher {
+	return func(device *Device) bool {
+		return device != nil && device.Name() == name
+	}
+}
+
+// WithID matches a device by its id
+func WithID(id string) DeviceMatcher {
+	return func(device *Device) bool {
+		return device != nil && device.ID() == id
+	}
+}
+
+// WithType matches a device by its type
+func WithType(t string) DeviceMatcher {
+	return func(device *Device) bool {
+		return device != nil && device.Type() == t
+	}
+}
+
+func matchAll(matchers ...DeviceMatcher) DeviceMatcher {
+	return func(device *Device) bool {
+		for _, m := range matchers {
+			if !m(device) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/discovery/zeroconf/scanner.go
+++ b/discovery/zeroconf/scanner.go
@@ -1,0 +1,75 @@
+// Package zeroconf provides a Scanner backed by the github.com/grandcat/zeroconf package
+package zeroconf
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/grandcat/zeroconf"
+	"github.com/sirupsen/logrus"
+	"github.com/vishen/go-chromecast/discovery"
+
+	"context"
+)
+
+// Scanner backed by the github.com/grandcat/zeroconf package
+// Nil values uses the default
+type Scanner struct {
+	Logger        logrus.FieldLogger
+	ClientOptions []zeroconf.ClientOption
+}
+
+// Scan repeatedly scans the network and sends the chromecast found into the results channel.
+// It finishes when the context is done.
+func (s Scanner) Scan(ctx context.Context, results chan<- *discovery.Device) error {
+	// generate entries
+	// Discover all services on the network (e.g. _workstation._tcp)
+	resolver, err := zeroconf.NewResolver(s.ClientOptions...)
+	if err != nil {
+		return fmt.Errorf("failed to initialize resolver: %w", err)
+	}
+
+	entries := make(chan *zeroconf.ServiceEntry, 5)
+	err = resolver.Browse(ctx, "_googlecast._tcp", "local", entries)
+	if err != nil {
+		return fmt.Errorf("fail to browse services: %w", err)
+	}
+
+	go func() {
+		defer close(results)
+		// decode entries
+		for e := range entries {
+			c, err := s.decode(e)
+			if err != nil {
+				if s.Logger != nil {
+					s.Logger.Errorf("could not decode: %w", err)
+				}
+				continue
+			}
+			select {
+			case results <- c:
+				continue
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// decode turns an zeroconf.ServiceEntry into a discovery.Device
+func (s Scanner) decode(entry *zeroconf.ServiceEntry) (*discovery.Device, error) {
+	if !strings.Contains(entry.Service, "_googlecast.") {
+		return nil, fmt.Errorf("fdqn '%s does not contain '_googlecast.'", entry.Service)
+	}
+
+	var ip net.IP
+	if len(entry.AddrIPv6) > 0 {
+		ip = entry.AddrIPv6[0]
+	} else if len(entry.AddrIPv4) > 0 {
+		ip = entry.AddrIPv4[0]
+	}
+
+	return discovery.NewDevice(ip, entry.Port, entry.Text), nil
+}

--- a/discovery/zeroconf/scanner_test.go
+++ b/discovery/zeroconf/scanner_test.go
@@ -1,0 +1,9 @@
+package zeroconf_test
+
+import (
+	"github.com/vishen/go-chromecast/discovery"
+	"github.com/vishen/go-chromecast/discovery/zeroconf"
+)
+
+// Ensure interface is satisfied
+var _ discovery.Scanner = zeroconf.Scanner{}

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -1,3 +1,4 @@
+// Package dns got superseeded by the package discovery
 package dns
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.12
 require (
 	cloud.google.com/go v0.37.2
 	github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/gogo/protobuf v1.2.1
+	github.com/grandcat/zeroconf v0.0.0-20180329153754-df75bb3ccae1
 	github.com/hashicorp/mdns v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jroimartin/gocui v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23 h1:D21IyuvjDCshj1/qq+pCNd3VZOAEI9jy6Bi131YlXgI=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/cenkalti/backoff v1.1.0 h1:QnvVp8ikKCDWOsFheytRCoYWYPO/ObCTBGxT19Hc+yE=
+github.com/cenkalti/backoff v1.1.0/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -56,6 +60,8 @@ github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/grandcat/zeroconf v0.0.0-20180329153754-df75bb3ccae1 h1:VSELJSxQlpi1bz4ZwT+93hPpzNLRcgytLr77iVRJpcE=
+github.com/grandcat/zeroconf v0.0.0-20180329153754-df75bb3ccae1/go.mod h1:YjKB0WsLXlMkO9p+wGTCoPIDGRJH0mz7E526PxkQVxI=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.6.2/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=

--- a/testdata/helptext.txt
+++ b/testdata/helptext.txt
@@ -38,6 +38,7 @@ Flags:
   -d, --device string        chromecast device, ie: 'Chromecast' or 'Google Home Mini'
   -n, --device-name string   chromecast device name
       --disable-cache        disable the cache
+  -f, --first                use the first chromecast device found
   -h, --help                 help for go-chromecast
   -i, --iface string         Network interface to use when looking for a local address to use for the http server
   -p, --port string          Port of the chromecast device if 'addr' is specified (default "8009")


### PR DESCRIPTION
_Fixes #58_ 

This PR adds a `--first` flag (`-f` shorthand) to the root command.

When this flag is set, the first Chromecast to be found while scanning will be used.

Regarding the implementation, I mostly took over my own code from https://github.com/oliverpool/go-chromecast/tree/master/discovery and adjusted it to implement the `CastDNSEntry` interface.

As-is, it should be a non-breaking change (since I didn't alter the exported code).

---

A further refactor could get rid of the `CastDNSEntry` interface, as it only uses the address of the Chromecast (which could be passed as a string to the application) - this is a breaking change, since `application.Start` is exported (but probably not used outside of this project).

What do you think?