### PR TITLE
Added transcoded command

### DIFF
--- a/cmd/transcode.go
+++ b/cmd/transcode.go
@@ -1,0 +1,70 @@
+// Copyright © 2018 Jonathan Pentecost <pentecostjonathan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vishen/go-chromecast/ui"
+)
+
+// transcodeCmd represents the transcode command
+var transcodeCmd = &cobra.Command{
+	Use:   "transcode",
+	Short: "Transcode and play media on the chromecast",
+	Long: `Transcode and play media on the chromecast. This will start a streaming server
+locally and serve the output of the transcoding operation to the chromecast. 
+This command requires the program or script to write the media content to stdout.
+The transcoded media content-type is required as well`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		app, err := castApplication(cmd, args)
+		if err != nil {
+			fmt.Printf("unable to get cast application: %v\n", err)
+			return nil
+		}
+
+		contentType, _ := cmd.Flags().GetString("content-type")
+		command, _ := cmd.Flags().GetString("command")
+
+		runWithUI, _ := cmd.Flags().GetBool("with-ui")
+		if runWithUI {
+			go func() {
+				if err := app.Transcode(command, contentType); err != nil {
+					logrus.WithError(err).Fatal("unable to load media")
+				}
+			}()
+
+			ccui, err := ui.NewUserInterface(app)
+			if err != nil {
+				logrus.WithError(err).Fatal("unable to prepare a new user-interface")
+			}
+			return ccui.Run()
+		}
+
+		if err := app.Transcode(command, contentType); err != nil {
+			fmt.Printf("unable to transcode media: %v\n", err)
+			return nil
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(transcodeCmd)
+	transcodeCmd.Flags().String("command", "", "command to use when transcoding")
+	transcodeCmd.Flags().StringP("content-type", "c", "", "content-type to serve the media file as")
+}

--- a/testdata/helptext.txt
+++ b/testdata/helptext.txt
@@ -28,6 +28,7 @@ Available Commands:
   slideshow   Play a slideshow of photos
   status      Current chromecast status
   stop        Stop casting
+  transcode   Transcode and play media on the chromecast
   tts         text-to-speech
   ui          Run the UI
   unmute      Unmute the chromecast


### PR DESCRIPTION
Added a new command : transcode.
It needs 2 flags to be set in order to work:
-  content-type : string containing the content-type of what the transcoded output should have
-  command : string containing the command to execute. It should write its output to stdout

It's almost a rip off of the load command except its aim is to handle borderline case that the load command can't