### PR TITLE
TTS: Added voice-name attribute for tts instead of languageCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,5 +311,5 @@ For non en-US languages
 
 ```
 $ go-chromecast tts <message_to_say> --google-service-account=/path/to/service/account.json \
-  --voice-name pl-PL-Wavenet-A
+  --voice-name en-US-Wavenet-G
 ```

--- a/README.md
+++ b/README.md
@@ -311,5 +311,5 @@ For non en-US languages
 
 ```
 $ go-chromecast tts <message_to_say> --google-service-account=/path/to/service/account.json \
-  --language-code ja-JP
+  --voice-name pl-PL-Wavenet-A
 ```

--- a/cmd/tts.go
+++ b/cmd/tts.go
@@ -40,7 +40,7 @@ var ttsCmd = &cobra.Command{
 			return
 		}
 
-		languageCode, _ := cmd.Flags().GetString("language-code")
+		voiceName, _ := cmd.Flags().GetString("voice-name")
 
 		b, err := ioutil.ReadFile(googleServiceAccount)
 		if err != nil {
@@ -54,7 +54,7 @@ var ttsCmd = &cobra.Command{
 			return
 		}
 
-		data, err := tts.Create(args[0], b, languageCode)
+		data, err := tts.Create(args[0], b, voiceName)
 		if err != nil {
 			fmt.Printf("%v\n", err)
 			return
@@ -88,5 +88,5 @@ var ttsCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(ttsCmd)
 	ttsCmd.Flags().String("google-service-account", "", "google service account JSON file")
-	ttsCmd.Flags().String("language-code", "en-US", "text-to-speech Language Code (de-DE, ja-JP,...)")
+	ttsCmd.Flags().String("voice-name", "pl-PL", "text-to-speech Voice (pl-PL-Wavenet-A, pl-PL-Wavenet-B, pl-PL-Wavenet-C, pl-PL-Wavenet-D, pl-PL-Wavenet-E)")
 }

--- a/cmd/tts.go
+++ b/cmd/tts.go
@@ -88,5 +88,5 @@ var ttsCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(ttsCmd)
 	ttsCmd.Flags().String("google-service-account", "", "google service account JSON file")
-	ttsCmd.Flags().String("voice-name", "pl-PL", "text-to-speech Voice (pl-PL-Wavenet-A, pl-PL-Wavenet-B, pl-PL-Wavenet-C, pl-PL-Wavenet-D, pl-PL-Wavenet-E)")
+	ttsCmd.Flags().String("voice-name", "en-US", "text-to-speech Voice (en-US-Wavenet-G, pl-PL-Wavenet-A, pl-PL-Wavenet-B, de-DE-Wavenet-A)")
 }

--- a/tts/tts.go
+++ b/tts/tts.go
@@ -29,12 +29,12 @@ func Create(sentence string, serviceAccountKey []byte, voiceName string) ([]byte
 			InputSource: &texttospeechpb.SynthesisInput_Text{Text: sentence},
 		},
 		Voice: &texttospeechpb.VoiceSelectionParams{
-			Name: voiceName
+			Name: voiceName,
 		},
 		AudioConfig: &texttospeechpb.AudioConfig{
 			AudioEncoding: texttospeechpb.AudioEncoding_MP3,
 			SpeakingRate: 1.0,
-			Pitch: 1.0
+			Pitch: 1.0,
 		},
 	}
 

--- a/tts/tts.go
+++ b/tts/tts.go
@@ -15,7 +15,7 @@ const (
 	timeout = time.Second * 10
 )
 
-func Create(sentence string, serviceAccountKey []byte, languageCode string) ([]byte, error) {
+func Create(sentence string, serviceAccountKey []byte, voiceName string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -29,11 +29,12 @@ func Create(sentence string, serviceAccountKey []byte, languageCode string) ([]b
 			InputSource: &texttospeechpb.SynthesisInput_Text{Text: sentence},
 		},
 		Voice: &texttospeechpb.VoiceSelectionParams{
-			LanguageCode: languageCode,
-			SsmlGender:   texttospeechpb.SsmlVoiceGender_NEUTRAL,
+			Name: voiceName
 		},
 		AudioConfig: &texttospeechpb.AudioConfig{
 			AudioEncoding: texttospeechpb.AudioEncoding_MP3,
+			SpeakingRate: 1.0,
+			Pitch: 1.0
 		},
 	}
 


### PR DESCRIPTION
Voice name is more powerful.

Google docs I have used: [LINK](https://cloud.google.com/text-to-speech/docs/reference/rpc/google.cloud.texttospeech.v1#google.cloud.texttospeech.v1.SynthesizeSpeechRequest)
Available voices: https://cloud.google.com/text-to-speech/

Could you create a release after merging this PR? 
I would do it myself, but I have troubles installing goreleaser. 

Thanks in advance
Bartek