### PR TITLE
cmd/load-app: Load chromecast App and Content ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Available Commands:
   help        Help about any command
   httpserver  Start the HTTP server
   load        Load and play media on the chromecast
+  load-app    Load and play content on a chromecast app
   ls          List devices
   mute        Mute the chromecast
   next        Play the next available media

--- a/testdata/helptext.txt
+++ b/testdata/helptext.txt
@@ -16,6 +16,7 @@ Available Commands:
   help        Help about any command
   httpserver  Start the HTTP server
   load        Load and play media on the chromecast
+  load-app    Load and play content on a chromecast app
   ls          List devices
   mute        Mute the chromecast
   next        Play the next available media


### PR DESCRIPTION
Add a new command to load a specific app on the chromecast and play the
content id. This should be useful for loading media on arbitrary
chromecast apps.

Updates: #90