### PR TITLE
Allow to choose the Streaming Server port

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -77,7 +77,7 @@ type Application struct {
 	volumeMedia    *cast.Volume
 	volumeReceiver *cast.Volume
 
-	httpServer *http.Server
+	httpServer *http.ServeMux
 	serverPort int
 	localIP    string
 	iface      *net.Interface
@@ -974,9 +974,9 @@ func (a *Application) startStreamingServer() error {
 	a.serverPort = listener.Addr().(*net.TCPAddr).Port
 	a.log("found available port :%d", a.serverPort)
 
-	a.httpServer = &http.Server{}
+	a.httpServer = http.NewServeMux()
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	a.httpServer.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Check to see if we have a 'filename' and if it is one of the ones that have
 		// already been validated and is useable.
 		filename := r.URL.Query().Get("media_file")
@@ -1019,7 +1019,7 @@ func (a *Application) startStreamingServer() error {
 
 	go func() {
 		a.log("media server listening on %d", a.serverPort)
-		if err := a.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if err := http.Serve(listener, a.httpServer); err != nil && err != http.ErrServerClosed {
 			log.WithField("package", "application").WithError(err).Fatal("error serving HTTP")
 		}
 	}()
@@ -1160,9 +1160,9 @@ func (a *Application) startTranscodingServer(command string) error {
 	a.serverPort = listener.Addr().(*net.TCPAddr).Port
 	a.log("found available port :%d", a.serverPort)
 
-	a.httpServer = &http.Server{}
+	a.httpServer = http.NewServeMux()
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	a.httpServer.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Check to see if we have a 'filename' and if it is one of the ones that have
 		// already been validated and is useable.
 		filename := r.URL.Query().Get("media_file")
@@ -1208,7 +1208,7 @@ func (a *Application) startTranscodingServer(command string) error {
 
 	go func() {
 		a.log("media server listening on %d", a.serverPort)
-		if err := a.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if err := http.Serve(listener, a.httpServer); err != nil && err != http.ErrServerClosed {
 			log.WithField("package", "application").WithError(err).Fatal("error serving HTTP")
 		}
 	}()

--- a/application/application.go
+++ b/application/application.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -100,6 +101,12 @@ type ApplicationOption func(*Application)
 func WithIface(iface *net.Interface) ApplicationOption {
 	return func(a *Application) {
 		a.iface = iface
+	}
+}
+
+func WithServerPort(port int) ApplicationOption {
+	return func(a *Application) {
+		a.serverPort = port
 	}
 }
 
@@ -966,7 +973,7 @@ func (a *Application) startStreamingServer() error {
 	}
 	a.log("trying to find available port to start streaming server on")
 
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", ":"+strconv.Itoa(a.serverPort))
 	if err != nil {
 		return errors.Wrap(err, "unable to bind to local tcp address")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("addr", "a", "", "Address of the chromecast device")
 	rootCmd.PersistentFlags().StringP("port", "p", "8009", "Port of the chromecast device if 'addr' is specified")
 	rootCmd.PersistentFlags().StringP("iface", "i", "", "Network interface to use when looking for a local address to use for the http server or for use with multicast dns discovery")
+	rootCmd.PersistentFlags().IntP("server-port", "s", 0, "Listening port for the http server")
 	rootCmd.PersistentFlags().Int("dns-timeout", 3, "Multicast DNS timeout in seconds when searching for chromecast DNS entries")
 	rootCmd.PersistentFlags().Bool("first", false, "Use first cast device found")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -65,6 +65,7 @@ func castApplication(cmd *cobra.Command, args []string) (*application.Applicatio
 	addr, _ := cmd.Flags().GetString("addr")
 	port, _ := cmd.Flags().GetString("port")
 	ifaceName, _ := cmd.Flags().GetString("iface")
+	serverPort, _ := cmd.Flags().GetInt("server-port")
 	dnsTimeoutSeconds, _ := cmd.Flags().GetInt("dns-timeout")
 	useFirstDevice, _ := cmd.Flags().GetBool("first")
 
@@ -75,6 +76,7 @@ func castApplication(cmd *cobra.Command, args []string) (*application.Applicatio
 	}
 
 	applicationOptions := []application.ApplicationOption{
+		application.WithServerPort(serverPort),
 		application.WithDebug(debug),
 		application.WithCacheDisabled(disableCache),
 	}

--- a/testdata/helptext.txt
+++ b/testdata/helptext.txt
@@ -49,6 +49,7 @@ Flags:
   -h, --help                 help for go-chromecast
   -i, --iface string         Network interface to use when looking for a local address to use for the http server or for use with multicast dns discovery
   -p, --port string          Port of the chromecast device if 'addr' is specified (default "8009")
+  -s, --server-port int      Listening port for the http server
   -u, --uuid string          chromecast device uuid
       --verbose              verbose logging
       --version              display command version


### PR DESCRIPTION
New option: -s, --server-port
If the option is omitted, the behavior is the same than before.

This is required if a firewall is blocking ports on the local machine
