### PR TITLE
fix cmd/playlist report zero playable files with foreign dir

### DIFF
--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -69,7 +69,7 @@ that ffmpeg is installed.`,
 		}
 		filesToPlay := make([]mediaFile, 0, len(files))
 		for _, f := range files {
-			if !forcePlay && !app.PlayableMediaType(f.Name()) {
+			if !forcePlay && !app.PlayableMediaType(filepath.Join(args[0], f.Name())) {
 				continue
 			}
 


### PR DESCRIPTION
Given a video file `a.mp4` in playlist `/video`, `Application.PlayableMediaType()` receives only `a.mp4`, which makes the `filetype.MatchFile()` in `Application.possibleContentType()` resolves it to `./a.mp4`, thus returns `os.ErrNotExist`

This commit fixes this bug.