### PR TITLE
dns: attempt to decode escaped utf8 name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,8 @@ name: Test
 
 on: 
   push:
-    - master
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push, pull_request]
+on: 
+  push:
+    - master
+  pull_request:
 
 jobs:
   test:

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -1,0 +1,40 @@
+package dns
+
+import (
+	"testing"
+)
+
+func TestDecode(t *testing.T) {
+	testCases := []struct {
+		val      string
+		expected string
+	}{
+		{
+			val:      "\\208\\161\\209\\130\\208\\176\\209\\129: \\208\\154\\208\\190\\208\\187\\208\\190\\208\\189\\208\\186\\208\\176",
+			expected: "Стас: Колонка",
+		},
+		{
+			val:      "\\208\\161\\209\\130\\208\\176\\209\\129: ABCDEF  HIJ\\208\\154\\208\\190\\208\\187\\208\\190\\208\\189\\208\\186\\208\\176",
+			expected: "Стас: ABCDEF  HIJКолонка",
+		},
+		{
+			val:      "contains no escape characters",
+			expected: "contains no escape characters",
+		},
+		{
+			val:      "contains some \\escape characters",
+			expected: "contains some \\escape characters",
+		},
+		{
+			val:      "contains some \\escape numbers: \\20",
+			expected: "contains some \\escape numbers: \\20",
+		},
+	}
+
+	for _, tt := range testCases {
+		decoded := decode(tt.val)
+		if decoded != tt.expected {
+			t.Errorf("decoded to %s, but expected %s", decoded, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
Some DNS entries seem to include escaped utf8 bytes in the name, ie:
'"\200\300\200"'. Attempt to decode the utf8 bytes if it looks like they
are present in the name.