### PR TITLE
Fix exit behavior for load with UI

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -60,6 +60,7 @@ that ffmpeg is installed.`,
 			if err := ccui.Run(); err != nil {
 				exit("unable to run ui: %v", err)
 			}
+			return
 		}
 
 		// Otherwise just run in CLI mode:


### PR DESCRIPTION
When the load subcommand executes, if the UI is loaded, the load is
launched in a go routine, then the UI is started on the main thread.  On
the other hand, if the UI is not started, the load subcommand executes
on the main thread.  However, on exit-ing the UI, the thread
inappropriately continues and re-executes the load, causing the casting
to restart from the beginning.  This simple fix causes the UI path to
return instead of falling through to the non-UI path.

Note, this behavior is benign when the video is playing, and exiting the
UI does not appear to cause any bad behavior.  However, if a video is
played to the end, such the 'load' execution is completed, then, when
exiting the UI, the second invocation of load will cause the video to
begin playing once more.

Signed-off-by: Jason Yellick <jason-github@unaddressable.org>