### PR TITLE
Add a togglepause command

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -94,18 +94,18 @@ type Application struct {
 	resultChanMap map[int]chan *pb.CastMessage
 
 	messageMu sync.Mutex
-	// Relay messages receieved so users can add custom logic to
+	// Relay messages received so users can add custom logic to
 	// events.
 	messageChan chan *pb.CastMessage
-	// Functions that will receieve messages from 'messageChan'
+	// Functions that will receive messages from 'messageChan'
 	messageFuncs []CastMessageFunc
 
 	// Current values from the chromecast.
 	application *cast.Application // It is possible that there is no current application, can happen for google home.
 	media       *cast.Media
 	// There seems to be two different volumes returned from the chromecast,
-	// one for the receiever and one for the playing media. It looks we update
-	// the receiever volume from go-chromecast so we should use that one. But
+	// one for the receiver and one for the playing media. It looks we update
+	// the receiver volume from go-chromecast, so we should use that one. But
 	// we will keep the other one around in-case we need it at some point.
 	volumeMedia    *cast.Volume
 	volumeReceiver *cast.Volume
@@ -124,7 +124,7 @@ type Application struct {
 	cache         *storage.Storage
 
 	// Number of connection retries to try before returning
-	// and error.
+	// an error.
 	connectionRetries int
 }
 

--- a/application/application.go
+++ b/application/application.go
@@ -67,6 +67,7 @@ type App interface {
 	Update() error
 	Pause() error
 	Unpause() error
+	TogglePause() error
 	Stop() error
 	StopMedia() error
 	Seek(value int) error
@@ -423,6 +424,22 @@ func (a *Application) Unpause() error {
 		PayloadHeader:  cast.PlayHeader,
 		MediaSessionId: a.media.MediaSessionId,
 	})
+}
+
+func (a *Application) TogglePause() error {
+	if a.media == nil {
+		return ErrNoMediaTogglePause
+	}
+	switch a.media.PlayerState {
+	case "PLAYING", "BUFFERING":
+		{
+			return a.Pause()
+		}
+	default:
+		{
+			return a.Unpause()
+		}
+	}
 }
 
 func (a *Application) Skipad() error {

--- a/application/errors.go
+++ b/application/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrNoMediaSkip            = errors.New("media not yet initialised, there is nothing to skip")
 	ErrNoMediaStop            = errors.New("media not yet initialised, there is nothing to stop")
 	ErrNoMediaUnpause         = errors.New("media not yet initialised, there is nothing to unpause")
+	ErrNoMediaTogglePause     = errors.New("media not yet initialised, there is nothing to (un)pause")
 	ErrNoMediaSkipad          = errors.New("No ad detected, there is nothing to skip")
 	ErrVolumeOutOfRange       = errors.New("specified volume is out of range (0 - 1)")
 	ErrAdMaxLoop              = errors.New("Unable to skip ad for unknown reason")

--- a/cast/connection.go
+++ b/cast/connection.go
@@ -61,7 +61,7 @@ func (c *Connection) Start(addr string, port int) error {
 			return err
 		}
 		var ctx context.Context
-		// TODO: Recieve context through function params?
+		// TODO: Receive context through function params?
 		ctx, c.cancel = context.WithCancel(context.Background())
 		go c.receiveLoop(ctx)
 	}

--- a/cmd/togglepause.go
+++ b/cmd/togglepause.go
@@ -20,8 +20,9 @@ import (
 
 // togglepauseCmd represents the togglepause command
 var togglepauseCmd = &cobra.Command{
-	Use:   "togglepause",
-	Short: "Toggle paused/unpaused state of the currently playing media on the chromecast",
+	Use:     "togglepause",
+	Aliases: []string{"tpause", "playpause"},
+	Short:   "Toggle paused/unpaused state. Aliases: tpause, playpause",
 	Run: func(cmd *cobra.Command, args []string) {
 		app, err := castApplication(cmd, args)
 		if err != nil {

--- a/cmd/togglepause.go
+++ b/cmd/togglepause.go
@@ -1,0 +1,38 @@
+// Copyright © 2018 Jonathan Pentecost <pentecostjonathan@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// togglepauseCmd represents the togglepause command
+var togglepauseCmd = &cobra.Command{
+	Use:   "togglepause",
+	Short: "Toggle paused/unpaused state of the currently playing media on the chromecast",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := castApplication(cmd, args)
+		if err != nil {
+			exit("unable to get cast application: %v", err)
+		}
+		if err := app.TogglePause(); err != nil {
+			exit("unable to (un)pause cast application: %v", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(togglepauseCmd)
+}


### PR DESCRIPTION
I have added the `togglepause` command that will toggle the paused/unpaused state of the currently playing media. It works by checking the current state and then pausing/unpausing accordingly.  
This is convenient when using `go-chromecast` in other scripts. Previously, this wasn't possible without first checking the current state with a separate command.

I have also added `tpause` and `playpause` as aliases and fixed a few typos and misspellings that I noticed along the way.

Please look through my changes and let me know what you think!