### PR TITLE
fix: Fix Goroutine leak after calling Close

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -399,6 +399,9 @@ func (a *Application) Close(stopMedia bool) error {
 		a.sendMediaConn(&cast.CloseHeader)
 		a.sendDefaultConn(&cast.CloseHeader)
 	}
+	defer func() {
+		close(a.messageChan)
+	}()
 	return a.conn.Close()
 }
 

--- a/cast/connection.go
+++ b/cast/connection.go
@@ -74,6 +74,9 @@ func (c *Connection) Close() error {
 	if c.cancel != nil {
 		c.cancel()
 	}
+	defer func() {
+		close(c.recvMsgChan)
+	}()
 	return c.conn.Close()
 }
 


### PR DESCRIPTION
Hello!

go-chromecast is an amazing tool. I am writing a Go implementation of sponsorblockcast called [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip) and have noticed if a device disconnects and I call `Application.Close()`, some Goroutines never exit resulting in a slight memory leak.

The problematic functions are:
- [`Application.messageChanHandler()`](https://github.com/vishen/go-chromecast/blob/540b4afe3aa42821079c56e11f29d620185fb81d/application/application.go#L212) due to [`Application.messageChan`](https://github.com/vishen/go-chromecast/blob/540b4afe3aa42821079c56e11f29d620185fb81d/application/application.go#L100) not being closed.
- [`Application.recvMessages()`](https://github.com/vishen/go-chromecast/blob/540b4afe3aa42821079c56e11f29d620185fb81d/application/application.go#L244) due to [`Connection.recvMsgChan`](https://github.com/vishen/go-chromecast/blob/540b4afe3aa42821079c56e11f29d620185fb81d/cast/connection.go#L39) not being closed.

This PR closes those channels when `Application.Close()` and `Connection.Close()` are called. I opted to close the channels in a `defer` so that they stay open while the underlying connection is closed. Let me know if you have any feedback!