### PR TITLE
fix: React to `CLOSE` messages

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -292,6 +292,9 @@ func (a *Application) recvMessages() {
 				}
 				a.volumeReceiver = &resp.Status.Volume
 			}
+		case "CLOSE":
+			a.MediaFinished()
+			a.application, a.media, a.volumeReceiver = nil, nil, nil
 		}
 		// Relay the event to any user specified message funcs.
 		a.messageChan <- msg


### PR DESCRIPTION
It seems like all Cast devices send a `CLOSE` message when the stream is stopped. Most devices also unset media info, but some devices (In my case, an older Sony XBR-55X850D TV) will respond in a way that causes application, media, and volumeReceiver to not get unset. This PR makes those values get set to `nil` if a `CLOSE` message occurs. I'm pretty new to the Cast API so this may not be the best way to handle this. Let me know what you think!