### PR TITLE
fix: Ensure channels are only closed once

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -97,7 +97,8 @@ type Application struct {
 	messageMu sync.Mutex
 	// Relay messages received so users can add custom logic to
 	// events.
-	messageChan chan *pb.CastMessage
+	messageChan   chan *pb.CastMessage
+	closeChanOnce sync.Once
 	// Functions that will receive messages from 'messageChan'
 	messageFuncs []CastMessageFunc
 
@@ -424,9 +425,9 @@ func (a *Application) Close(stopMedia bool) error {
 		a.sendMediaConn(&cast.CloseHeader)
 		a.sendDefaultConn(&cast.CloseHeader)
 	}
-	defer func() {
+	defer a.closeChanOnce.Do(func() {
 		close(a.messageChan)
-	}()
+	})
 	return a.conn.Close()
 }
 


### PR DESCRIPTION
Ever since #166, `application.Close()` will panic with `close of closed channel` if closed more than once. This PR wraps the close call with `sync.Once.Do()` so that it can only be called once. This will cause the channel close to simply be skipped after the first call.

This could also be done with a non-blocking select, but has the downside of skipping the close if one of the channels happens to have data at the time that close is called. Let me know if you prefer this other method:
```go
defer func() {
  select {
    case <-a.messageChan:
      // chan probably closed
    default:
      // chan not closed
      close(a.messageChan)
  }
}()
```