### PR TITLE
scanner: provide device name

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -25,7 +25,6 @@ import (
 	pb "github.com/vishen/go-chromecast/cast/proto"
 	"github.com/vishen/go-chromecast/playlists"
 	"github.com/vishen/go-chromecast/storage"
-	"gopkg.in/ini.v1"
 	"path/filepath"
 )
 
@@ -1426,13 +1425,4 @@ func (a *Application) Transcode(contentType string, command string, args ...stri
 	// Wait until we have been notified that the media has finished playing
 	a.MediaWait()
 	return nil
-}
-
-// plsIterator is an iterator for playlist-files.
-// According to https://en.wikipedia.org/wiki/PLS_(file_format),
-// The format is case-sensitive and essentially that of an INI file.
-// It has entries on the form File1, Title1 etc.
-type plsIterator struct {
-	count    int
-	playlist *ini.Section
 }

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -4,16 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
-	"fmt"
-	"path/filepath"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/vishen/go-chromecast/application"
 	"github.com/vishen/go-chromecast/cast"
 	mockCast "github.com/vishen/go-chromecast/cast/mocks"
 	pb "github.com/vishen/go-chromecast/cast/proto"
-	"github.com/vishen/go-chromecast/playlists"
 )
 
 var mockAddr = "foo.bar"
@@ -45,33 +41,4 @@ func TestApplicationStart(t *testing.T) {
 	conn.On("Send", mock.IsType(0), mock.IsType(&cast.ConnectHeader), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
 	app := application.NewApplication(application.WithConnection(conn))
 	assertions.NoError(app.Start(mockAddr, mockPort))
-}
-
-func TestParsePlaylist(t *testing.T) {
-	var path string
-	if abs, err := filepath.Abs(filepath.Join("..", "testdata", "indiepop64.pls")); err != nil {
-		t.Fatal(err)
-	} else {
-		path = fmt.Sprintf("file://%v", abs)
-	}
-	it, err := playlists.NewIterator(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var wantUrls = []string{
-		"https://ice4.somafm.com/indiepop-64-aac",
-		"https://ice2.somafm.com/indiepop-64-aac",
-		"https://ice1.somafm.com/indiepop-64-aac",
-		"https://ice6.somafm.com/indiepop-64-aac",
-		"https://ice5.somafm.com/indiepop-64-aac",
-	}
-	for i, want := range wantUrls {
-		if !it.HasNext() {
-			t.Fatal("iterator exhausted")
-		}
-		have, _ := it.Next()
-		if have != want {
-			t.Fatalf("url %d, have %v want %v", i, have, want)
-		}
-	}
 }


### PR DESCRIPTION
This PR uses the http interface at `8008:setup/eureka_info` to pick out the device name, if a device has been found via scanning. 

```
$ go run .  scan --cidr 192.168.50.0/24 
Scanning...  scanned 0, current 192.168.50.0
  - 'Office speaker' at 192.168.50.88:8009
Scanned 256 uris in 1.609840334s
```

Also removes some leftovers from a previous PR. 