### PR TITLE
Change fmt.Printf to log.Infof when adding items to playlist

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -786,7 +786,7 @@ func (a *Application) Load(filenameOrUrl string, startTime int, contentType stri
 				filename:   url,
 				contentURL: url,
 			})
-			fmt.Printf("Adding url %v (%v)\n", url, title)
+			log.Infof("Adding url %v (%v)", url, title)
 		}
 		return a.QueueLoadItems(items, "")
 	}


### PR DESCRIPTION
The `fmt.Printf` messages are interfering with the `--with-ui` option - this changes them to use the log methods instead which appear properly inside the UI Log area.