### PR TITLE
Support SSML in Speech-to-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,3 +327,11 @@ $ go-chromecast tts <message_to_say> --google-service-account=/path/to/service/a
 ```
 
 List of available voices (voice-name) can be found here: https://cloud.google.com/text-to-speech/
+
+Use [SSML](https://cloud.google.com/text-to-speech/docs/ssml)
+
+```
+$ go-chromecast tts '<speak>Hello<break time="500ms"/>world.</speak>' \
+  --google-service-account=/path/to/service/account.json \
+  --ssml
+```

--- a/cmd/tts.go
+++ b/cmd/tts.go
@@ -43,6 +43,7 @@ var ttsCmd = &cobra.Command{
 		voiceName, _ := cmd.Flags().GetString("voice-name")
 		speakingRate, _ := cmd.Flags().GetFloat32("speaking-rate")
 		pitch, _ := cmd.Flags().GetFloat32("pitch")
+		ssml, _ := cmd.Flags().GetBool("ssml")
 
 		b, err := ioutil.ReadFile(googleServiceAccount)
 		if err != nil {
@@ -54,7 +55,7 @@ var ttsCmd = &cobra.Command{
 			exit("unable to get cast application: %v", err)
 		}
 
-		data, err := tts.Create(args[0], b, languageCode, voiceName, speakingRate, pitch)
+		data, err := tts.Create(args[0], b, languageCode, voiceName, speakingRate, pitch, ssml)
 		if err != nil {
 			exit("unable to create tts: %v", err)
 		}
@@ -85,4 +86,5 @@ func init() {
 	ttsCmd.Flags().String("voice-name", "en-US-Wavenet-G", "text-to-speech Voice (en-US-Wavenet-G, pl-PL-Wavenet-A, pl-PL-Wavenet-B, de-DE-Wavenet-A)")
 	ttsCmd.Flags().Float32("speaking-rate", 1.0, "speaking rate")
 	ttsCmd.Flags().Float32("pitch", 1.0, "pitch")
+	ttsCmd.Flags().Bool("ssml", false, "use SSML")
 }

--- a/tts/tts.go
+++ b/tts/tts.go
@@ -15,7 +15,7 @@ const (
 	timeout = time.Second * 10
 )
 
-func Create(sentence string, serviceAccountKey []byte, languageCode string, voiceName string, speakingRate float32, pitch float32) ([]byte, error) {
+func Create(sentence string, serviceAccountKey []byte, languageCode string, voiceName string, speakingRate float32, pitch float32, ssml bool) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -24,10 +24,15 @@ func Create(sentence string, serviceAccountKey []byte, languageCode string, voic
 		return nil, errors.Wrap(err, "unable to create texttospeech client")
 	}
 
+	input := texttospeechpb.SynthesisInput{}
+	if ssml {
+		input.InputSource = &texttospeechpb.SynthesisInput_Ssml{Ssml: sentence}
+	} else {
+		input.InputSource = &texttospeechpb.SynthesisInput_Text{Text: sentence}
+	}
+
 	req := texttospeechpb.SynthesizeSpeechRequest{
-		Input: &texttospeechpb.SynthesisInput{
-			InputSource: &texttospeechpb.SynthesisInput_Text{Text: sentence},
-		},
+		Input: &input,
 		Voice: &texttospeechpb.VoiceSelectionParams{
 			LanguageCode: languageCode,
 			Name:         voiceName,


### PR DESCRIPTION
Hi,

go-chromecast is a very handy tool that I use every day on my home network.
I've tried making it even more convenient by supporting [SSML](https://cloud.google.com/text-to-speech/docs/ssml).

Added `--ssml` flag to treat messages as SSML

example:

```
go-chromecast tts '<speak>Hello<break time="500ms"/>world.</speak>' \
  --google-service-account /path/to/google-cred.json --ssml
```

Please consider merging if you like.