### PR TITLE
HTTP Server: Statuses can be collected in the background

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -393,7 +393,7 @@ func (a *Application) Update() error {
 		if err == nil {
 			break
 		}
-		a.log("error getting receiever status: %v", err)
+		a.log("error getting receiver status: %v", err)
 		a.log("unable to get status from device; attempt %d/5, retrying...", i+1)
 		time.Sleep(time.Second * 2)
 	}

--- a/cast/payload.go
+++ b/cast/payload.go
@@ -165,4 +165,5 @@ type DeviceInfo struct {
 	Ssid       string  `json:"ssid"`
 	Timezone   string  `json:"timezone"`
 	UptimeSec  float64 `json:"uptime"`
+	SsdpUdn    string  `json:"ssdp_udn"`
 }


### PR DESCRIPTION
The server's method /status was not updating the status in the app layer. 
As collecting all statuses for multiple devices is a slow operation, 
I'm proposing to add a background process to refresh them independently of requests.
