### PR TITLE
feat(dns): Add zeroconf client options to DNS params

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -62,8 +62,8 @@ func (e CastEntry) GetPort() int {
 
 // DiscoverCastDNSEntryByName returns the first cast dns device
 // found that matches the name.
-func DiscoverCastDNSEntryByName(ctx context.Context, iface *net.Interface, name string) (CastEntry, error) {
-	castEntryChan, err := DiscoverCastDNSEntries(ctx, iface)
+func DiscoverCastDNSEntryByName(ctx context.Context, iface *net.Interface, name string, opts ...zeroconf.ClientOption) (CastEntry, error) {
+	castEntryChan, err := DiscoverCastDNSEntries(ctx, iface, opts...)
 	if err != nil {
 		return CastEntry{}, err
 	}
@@ -78,8 +78,7 @@ func DiscoverCastDNSEntryByName(ctx context.Context, iface *net.Interface, name 
 
 // DiscoverCastDNSEntries will return a channel with any cast dns entries
 // found.
-func DiscoverCastDNSEntries(ctx context.Context, iface *net.Interface) (<-chan CastEntry, error) {
-	var opts = []zeroconf.ClientOption{}
+func DiscoverCastDNSEntries(ctx context.Context, iface *net.Interface, opts ...zeroconf.ClientOption) (<-chan CastEntry, error) {
 	if iface != nil {
 		opts = append(opts, zeroconf.SelectIfaces([]net.Interface{*iface}))
 	}


### PR DESCRIPTION
Hey! CastSponsorSkip dev here. I have some reports of errors due to zeroconf trying to bind to an IPv6 address when IPv6 is disabled in https://github.com/gabe565/CastSponsorSkip/issues/54. I suspect [zeroconf.SelectIPTraffic](https://pkg.go.dev/github.com/grandcat/zeroconf#SelectIPTraffic) could help, so this PR adds support for variadic parameters. This also allows for selecting multiple interfaces, by leaving the `iface` param set to nil, then passing `zeroconf.SelectIfaces` directly.

Honestly, it would probably be best practice to remove the `iface` param, but that would be a breaking change. If you prefer, I could change this PR to do something like this:
```go
func DiscoverCastDNSEntries(ctx context.Context, iface *net.Interface) (<-chan CastEntry, error) {
	var opts []zeroconf.ClientOption
	if iface != nil {
		opts = append(opts, zeroconf.SelectIfaces([]net.Interface{*iface}))
	}
	return DiscoverCastDNSEntriesV2(ctx, opts...)
}

func DiscoverCastDNSEntriesV2(ctx context.Context, opts ...zeroconf.ClientOption) (<-chan CastEntry, error) {
	resolver, err := zeroconf.NewResolver(opts...)
	if err != nil {
		return nil, fmt.Errorf("unable to create new zeroconf resolver: %w", err)
	}
        [...]
```