### PR TITLE
Recognize "audio/mpeg" as MP3 to skip transcoding

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -785,7 +785,7 @@ func (a *Application) castPlayableContentType(contentType string) bool {
 	switch contentType {
 	case "image/apng", "image/bmp", "image/gif", "image/jpeg", "image/png", "image/webp":
 		return true
-	case "audio/mp2t", "audio/mp3", "audio/mp4", "audio/ogg", "audio/wav", "audio/webm":
+	case "audio/mp2t", "audio/mpeg", "audio/mp3", "audio/mp4", "audio/ogg", "audio/wav", "audio/webm":
 		return true
 	case "video/mp4", "video/webm":
 		return true


### PR DESCRIPTION
Package github.com/h2non/filetype returns "audio/mpeg" for MP3 files. go-chromecast currently only expects "audio/mp3" which appears to be deprecated. This change adds "audio/mpeg" to the list of recognized types which seems to be the correct type per RFC 3003.