### PR TITLE
feat: Add volume up / down command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Available Commands:
   unmute      Unmute the chromecast
   unpause     Unpause the currently playing media on the chromecast
   volume      Get or set volume
+  volume-down Turn down volume
+  volume-up   Turn up volume
   watch       Watch all events sent from a chromecast device
 
 Flags:
@@ -201,6 +203,9 @@ $ go-chromecast volume
 
 # Set the volume level
 $ go-chromecast volume 0.55
+
+# Turn up the volume
+$ go-chromecast volume-up --step 0.10
 
 # View what messages a cast device is sending out.
 $ go-chromecast watch

--- a/cmd/volume-down.go
+++ b/cmd/volume-down.go
@@ -1,0 +1,57 @@
+// Copyright © 2025 leak4mk0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"math"
+
+	"github.com/spf13/cobra"
+)
+
+// volumeDownCmd represents the volume-down command
+var volumeDownCmd = &cobra.Command{
+	Use:   "volume-down",
+	Short: "Turn down volume",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := castApplication(cmd, args)
+		if err != nil {
+			exit("unable to get cast application: %v", err)
+		}
+
+		volumeStep, _ := cmd.Flags().GetFloat32("step")
+
+		if err = app.Update(); err != nil {
+			exit("unable to update cast info: %v", err)
+		}
+		_, _, castVolume := app.Status()
+
+		nextVolume := max(castVolume.Level-volumeStep, math.SmallestNonzeroFloat32)
+		if err = app.SetVolume(float32(nextVolume)); err != nil {
+			exit("failed to set volume: %v", err)
+		}
+
+		if err = app.Update(); err != nil {
+			exit("unable to update cast info: %v", err)
+		}
+		_, _, turnedCastVolume := app.Status()
+
+		outputInfo("%0.2f", turnedCastVolume.Level)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(volumeDownCmd)
+	volumeDownCmd.Flags().Float32("step", 0.05, "step value for turning down volume")
+}

--- a/cmd/volume-up.go
+++ b/cmd/volume-up.go
@@ -1,0 +1,55 @@
+// Copyright © 2025 leak4mk0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// volumeUpCmd represents the volume-up command
+var volumeUpCmd = &cobra.Command{
+	Use:   "volume-up",
+	Short: "Turn up volume",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := castApplication(cmd, args)
+		if err != nil {
+			exit("unable to get cast application: %v", err)
+		}
+
+		volumeStep, _ := cmd.Flags().GetFloat32("step")
+
+		if err = app.Update(); err != nil {
+			exit("unable to update cast info: %v", err)
+		}
+		_, _, castVolume := app.Status()
+
+		nextVolume := min(castVolume.Level+volumeStep, 1)
+		if err = app.SetVolume(float32(nextVolume)); err != nil {
+			exit("failed to set volume: %v", err)
+		}
+
+		if err = app.Update(); err != nil {
+			exit("unable to update cast info: %v", err)
+		}
+		_, _, turnedCastVolume := app.Status()
+
+		outputInfo("%0.2f", turnedCastVolume.Level)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(volumeUpCmd)
+	volumeUpCmd.Flags().Float32("step", 0.05, "step value for turning up volume")
+}


### PR DESCRIPTION
This PR adds volume up / down command.
How to use:
```bash
# Turn up the volume
$ go-chromecast volume-up
0.25

# Turn up the volume by 0.10
$ go-chromecast volume-up --step 0.10
0.35

# Turn down the volume
$ go-chromecast volume-down
0.30

# Turn down the volume by 0.10
$ go-chromecast volume-down --step 0.10
0.20
```