### PR TITLE
Deprecate statuses for status-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,13 +259,17 @@ $ go-chromecast --with-ui load /path/to/file.flac
 There is a HTTP API server provided that has the following api:
 
 ```
-GET /devices?interface=<network_interface>&wait=<seconds>
-POST /connect?uuid=<device_uuid>&addr=<device_addr>&port=<device_port>&interface=<network_interface>&wait=<seconds>
-POST /disconnect?uuid=<device_uuid>&stop=<bool>
-POST /disconnect-all?stop=<bool>
-POST /status?uuid=<device_uuid>
+GET /devices?wait=...&iface=...
+POST /connect?uuid=<device_uuid>&addr=<device_addr>&port=<device_port>
+POST /connect-all?wait=...&iface=...
+POST /disconnect?uuid=<device_uuid>
+POST /disconnect-all
+GET /status?uuid=<device_uuid>
+GET /statuses (Deprecated use status-all)
+GET /status-all
 POST /pause?uuid=<device_uuid>
 POST /unpause?uuid=<device_uuid>
+POST /skipad?uuid=<device_uuid>
 POST /mute?uuid=<device_uuid>
 POST /unmute?uuid=<device_uuid>
 POST /stop?uuid=<device_uuid>
@@ -274,7 +278,7 @@ POST /volume?uuid=<device_uuid>&volume=<float>
 POST /rewind?uuid=<device_uuid>&seconds=<int>
 POST /seek?uuid=<device_uuid>&seconds=<int>
 POST /seek-to?uuid=<device_uuid>&seconds=<float>
-POST /load?uuid=<device_uuid>&path=<filepath_or_url>&content_type=<string>
+POST /load?uuid=<device_uuid>&path=<filepath_or_url>&content_type=<string>&start_time=<int>
 ```
 
 ```

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishen/go-chromecast/application"
@@ -108,7 +109,8 @@ func (h *Handler) registerHandlers() {
 		POST /disconnect?uuid=<device_uuid>
 		POST /disconnect-all
 		GET /status?uuid=<device_uuid>
-		GET /statuses
+		GET /statuses (Deprecated use status-all)
+		GET /status-all
 		POST /pause?uuid=<device_uuid>
 		POST /unpause?uuid=<device_uuid>
 		POST /skipad?uuid=<device_uuid>
@@ -129,6 +131,7 @@ func (h *Handler) registerHandlers() {
 	h.mux.HandleFunc("/disconnect", h.disconnect)
 	h.mux.HandleFunc("/disconnect-all", h.disconnectAll)
 	h.mux.HandleFunc("/status", h.status)
+	h.mux.HandleFunc("/status-all", h.statusAll)
 	h.mux.HandleFunc("/statuses", h.statuses)
 	h.mux.HandleFunc("/pause", h.pause)
 	h.mux.HandleFunc("/unpause", h.unpause)
@@ -463,7 +466,17 @@ func (h *Handler) UpdateAll() error {
 	return g.Wait()
 }
 
+// Deprecated: Use statusAll instead
 func (h *Handler) statuses(w http.ResponseWriter, r *http.Request) {
+	dep_message := "/statuses is deprecated, use /status-all instead"
+	log.Warn(dep_message)
+
+	w.Header().Add("Deprecated", dep_message)
+
+	h.statusAll(w, r)
+}
+
+func (h *Handler) statusAll(w http.ResponseWriter, r *http.Request) {
 	h.log("statuses for devices")
 	syncUpdate := r.URL.Query().Get("syncUpdate") == "true"
 	uuids := h.ConnectedDeviceUUIDs()


### PR DESCRIPTION
Fixes #222

Rename statuses to status-all and use statuses as a wrapper with deprecation notices